### PR TITLE
Include field count in collapsed results

### DIFF
--- a/ValidationViewModel.cs
+++ b/ValidationViewModel.cs
@@ -22,8 +22,10 @@ namespace PlanCrossCheck
                 .GroupBy(r => r.Category)
                 .SelectMany(group =>
                 {
-                    bool allPass = group.All(r => r.Severity == ValidationSeverity.Info);
-                    bool allFieldMessages = group.All(r => r.Message.StartsWith("Field '"));
+                    var fieldResults = group.ToList();
+                    bool allPass = fieldResults.All(r => r.Severity == ValidationSeverity.Info);
+                    bool allFieldMessages = fieldResults.All(r => r.Message.StartsWith("Field '"));
+                    int fieldCount = fieldResults.Count;
 
                     if (allPass && allFieldMessages)
                     {
@@ -33,12 +35,14 @@ namespace PlanCrossCheck
                             {
                                 Category = group.Key,
                                 Severity = ValidationSeverity.Info,
-                                Message = $"All treatment fields passed {group.Key} checks"
+                                Message = fieldCount == 1
+                                    ? $"Field passed {group.Key} checks"
+                                    : $"All {fieldCount} treatment fields passed {group.Key} checks"
                             }
                         };
                     }
 
-                    return group;
+                    return fieldResults;
                 });
 
             foreach (var result in processedResults)


### PR DESCRIPTION
## Summary
- compute number of field validation results when collapsing
- include field count in the generated summary message

## Testing
- `msbuild PlanCrossCheck.sln /p:Configuration=Release /p:Platform=x64` *(command not found: msbuild)*
- `apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bac5c167ac83229bf717cd25ff9105